### PR TITLE
Fix float timestamp

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -50,7 +50,7 @@ Logger.prototype.send = function (tag, data, cb) {
   }
 
   if (this.type === 'forward' || this.type === 'secure_forward') {
-    var timestamp = new Date().valueOf() / 1000;
+    var timestamp = Math.floor(new Date().valueOf() / 1000);
     var packet = JSON.stringify([tag, timestamp, JSON.parse(data)]);
 
     this.writeStream.write(packet, cb);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "debug": "^2.1.3",
+    "server-destroy": "^1.0.1",
     "tape": "^3.5.0"
   },
   "scripts": {


### PR DESCRIPTION
Issue for fluent/fluentd#1220

`timestamp` must be integer not float in fact.